### PR TITLE
Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ plymouth-unsealtotp: plymouth-unsealtotp.c
 	$(CC) $(CFLAGS) $(PLYMOUTH_CFLAGS) -o $@ $< $(PLYMOUTH_LDLIBS) $(LDLIBS)
 
 sealtotp: sealtotp.c base32.c
-	$(CC) $(CFLAGS) -ltspi -lqrencode -o $@ $? $(LDLIBS)
+	$(CC) $(CFLAGS) -ltspi -lqrencode -o $@ $^ $(LDLIBS)
 
 clean:
 	rm -f *.o $(APPS)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS = -ggdb -w -Ilibtpm -std=c99 -Wall -Wextra -Werror
 
 PLYMOUTH_CFLAGS = `pkg-config --cflags ply-boot-client`
 
-LDLIBS=-Llibtpm -ltpm -lcrypto -loath -lqrencode
+LDLIBS=-Llibtpm -ltpm -lcrypto -loath
 
 PLYMOUTH_LDLIBS = `pkg-config --libs ply-boot-client`
 
@@ -20,7 +20,7 @@ plymouth-unsealtotp: plymouth-unsealtotp.c
 	$(CC) $(CFLAGS) $(PLYMOUTH_CFLAGS) -o $@ $< $(PLYMOUTH_LDLIBS) $(LDLIBS)
 
 sealtotp: sealtotp.c base32.c
-	$(CC) $(CFLAGS) -ltspi -o $@ $? $(LDLIBS)
+	$(CC) $(CFLAGS) -ltspi -lqrencode -o $@ $? $(LDLIBS)
 
 clean:
 	rm -f *.o $(APPS)


### PR DESCRIPTION
Only link sealtotop against libqrencode and make sure that base32.c is always passed as a compiler argument. 
